### PR TITLE
add owner command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ ec2 controller for ruboty
 
 ```ruby
 # Gemfile
-gem 'ruboty-ec2', '0.x.x', :git => 'git://github.com/miyaz/ruboty-ec2.git'
+gem 'ruboty-ec2', '0.x.x', :git => 'git://github.com/DreamArtsOkinawa/ruboty-ec2.git'
 ```
 
 ## ENV
@@ -22,5 +22,6 @@ RUBOTY_EC2_DOMAIN_{CN}          - Route53 Domain Name for each Channel
 RUBOTY_EC2_REGION_{CN}          - AWS region for each Channel. (default: ap-northeast-1)
 RUBOTY_EC2_EXCHANGE_RATE        - Exchange Rate (USD/JPY)
 RUBOTY_EC2_SUPER_ADMIN          - SuperAdmin UserName (comma separated variable)
+SLACK_API_TOKEN                 - Slack API Token to get User List
 ```
 

--- a/lib/ruboty/ec2/actions/owner.rb
+++ b/lib/ruboty/ec2/actions/owner.rb
@@ -1,0 +1,156 @@
+require 'pp'
+
+module Ruboty
+  module Ec2
+    module Actions
+      class Owner < Ruboty::Actions::Base
+        def call
+          puts "ec2 owner #{message[:cmd]} called"
+          cmd_name = message[:cmd]
+          ins_name = message[:ins_name]
+          to_user  = message[:to_user]
+          transfer if cmd_name == "transfer" and !ins_name.nil? and !to_user.nil?
+          absence  if cmd_name == "absence"
+        end
+
+        private
+
+        def transfer
+          # AWSアクセス、その他ユーティリティのインスタンス化
+          brain = Ruboty::Ec2::Helpers::Brain.new(message)
+          ec2   = Ruboty::Ec2::Helpers::Ec2.new(message)
+          slack = Ruboty::Ec2::Helpers::Slack.new(message)
+
+          # チャットコマンド情報取得
+          ins_name = message[:ins_name]
+          to_user  = message[:to_user]
+          
+          ## 事前チェック ##
+
+          # Slackユーザ名の一覧取得（今日初であればSlackAPIで取得してRedis保存）
+          today = Time.now.strftime('%Y-%m-%d')
+          brain_user_list = brain.get_slack_user_list
+          slack_user_list = nil
+          if brain_user_list.empty? or brain_user_list[:last_update] != today
+            puts "need to get slack user list by slack api"
+            slack_user_list = slack.get_slack_user_list
+            brain.save_slack_user_list(slack_user_list)
+          else
+            puts "found slack user list in brain"
+            slack_user_list = brain_user_list[:user_info]
+          end
+          # Slackユーザリスト取得成否チェック
+          raise "Slackユーザリストが取得できなかったよ..." if slack_user_list.empty?
+
+          ## 現在利用中のインスタンス／アーカイブ情報を取得
+          ins_infos = ec2.get_ins_infos(ins_name)
+          arc_infos = ec2.get_arc_infos(ins_name)
+
+          ## インスタンス存在チェック
+          if ins_infos[ins_name].nil? and arc_infos[ins_name].nil?
+            raise "インスタンス[#{ins_name}]が見つからないよ"
+          end
+
+          # Owner チェック
+          ins_or_arc = ''
+          resrc_id   = ''
+          fr_user    = ''
+          unless ins_infos[ins_name].nil?
+            ins_or_arc = 'インスタンス'
+            resrc_id   = ins_infos[ins_name][:instance_id]
+            fr_user    = ins_infos[ins_name][:owner]
+          else
+            ins_or_arc = 'アーカイブ'
+            resrc_id   = arc_infos[ins_name][:image_id]
+            fr_user    = arc_infos[ins_name][:owner]
+          end
+          if fr_user == to_user
+            raise "#{ins_or_arc}[#{ins_name}]のオーナーは既に[#{fr_user}]だよ"
+          end
+
+          # Slackユーザ存在／ステータスチェック
+          if slack_user_list[to_user].nil?
+            raise "Slackユーザ[#{to_user}]は存在しないよ"
+          elsif slack_user_list[to_user][:disabled]
+            raise "Slackユーザ[#{to_user}]は無効化されているよ"
+          end
+
+          ## メイン処理 ##
+
+          # タグ付け(オーナー変更)
+          params =  {"Owner" => to_user}
+          ec2.update_tags([resrc_id], params)
+
+          reply_msg  = "#{ins_or_arc}[#{ins_name}]のオーナーを[#{to_user}]に変更したよ"
+          message.reply(reply_msg)
+        rescue => e
+          message.reply(e.message)
+        end
+
+        def absence
+          # AWSアクセス、その他ユーティリティのインスタンス化
+          brain = Ruboty::Ec2::Helpers::Brain.new(message)
+          ec2   = Ruboty::Ec2::Helpers::Ec2.new(message)
+          slack = Ruboty::Ec2::Helpers::Slack.new(message)
+
+          ## 事前チェック ##
+
+          # Slackユーザ名の一覧取得（今日初であればSlackAPIで取得してRedis保存）
+          today = Time.now.strftime('%Y-%m-%d')
+          brain_user_list = brain.get_slack_user_list
+          slack_user_list = nil
+          if brain_user_list.empty? or brain_user_list[:last_update] != today
+            puts "need to get slack user list by slack api"
+            slack_user_list = slack.get_slack_user_list
+            brain.save_slack_user_list(slack_user_list)
+          else
+            puts "found slack user list in brain"
+            slack_user_list = brain_user_list[:user_info]
+          end
+          # Slackユーザリスト取得成否チェック
+          raise "Slackユーザリストが取得できなかったよ..." if slack_user_list.empty?
+
+          ## メイン処理 ##
+
+          ## 現在利用中のインスタンス／アーカイブ情報を取得
+          ins_infos = ec2.get_ins_infos
+          arc_infos = ec2.get_arc_infos
+
+          # OwnerがSlackユーザリストに存在しないものを抽出して表示
+          header_str = sprintf(" %15s | %18s | %s ",
+                               "- InsName -----", "- Owner ----------",  "- Status ------")
+          msg_list   = ""
+          ins_infos.each do |ins_name, ins_info|
+            owner = ins_info[:owner]
+            next if owner.nil? or owner.empty?
+            if !slack_user_list.has_key?(owner)
+              msg_list << sprintf("\n %-15s | %-18s | Not Found", ins_name, owner)
+            elsif slack_user_list[owner][:disabled]
+              msg_list << sprintf("\n %-15s | %-18s | Disabled", ins_name, owner)
+            end
+          end
+          reply_msg = "[インスタンス]\n```#{header_str}#{msg_list}```\n"
+          reply_msg = "[インスタンス]\nオーナー設定に問題はないよ\n" if msg_list.empty?
+          message.reply(reply_msg)
+
+          msg_list   = ""
+          arc_infos.each do |arc_name, arc_info|
+            owner = arc_info[:owner]
+            next if owner.nil? or owner.empty?
+            if !slack_user_list.has_key?(owner)
+#              msg_list << sprintf("\n %-15s | %-18s | Not Found", arc_name, owner)
+            elsif slack_user_list[owner][:disabled]
+#              msg_list << sprintf("\n %-15s | %-18s | Disabled", arc_name, owner)
+            end
+          end
+          reply_msg = "[アーカイブ]\n```#{header_str}#{msg_list}```"
+          reply_msg = "[アーカイブ]\nオーナー設定に問題はないよ" if msg_list.empty?
+          message.reply(reply_msg)
+        rescue => e
+          message.reply(e.message)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/ruboty/ec2/helpers/brain.rb
+++ b/lib/ruboty/ec2/helpers/brain.rb
@@ -4,29 +4,31 @@ module Ruboty
   module Ec2
     module Helpers
       class Brain
-        NAMESPACE = 'ec2'
+        CMN_NAMESPACE = 'common'
+        GEM_NAMESPACE = 'ec2'
         def initialize(message)
           puts "Ruboty::Ec2::Helpers::Brain.initialize called"
           @channel = Util.new(message).get_channel
-          message.robot.brain.data[NAMESPACE] ||= {}
-          @brain   = message.robot.brain.data[NAMESPACE][@channel] ||= {}
+          message.robot.brain.data[GEM_NAMESPACE] ||= {}
+          @gem_brain = message.robot.brain.data[GEM_NAMESPACE][@channel] ||= {}
+          @cmn_brain = message.robot.brain.data[CMN_NAMESPACE] ||= {}
         end
 
         def save_ins_uptime(ins_name, uptime, yyyymm = nil)
           puts "Ruboty::Ec2::Helpers::Brain.save_ins_uptime called"
           yyyymm = Time.now.strftime('%Y%m') if yyyymm.nil?
-          @brain[ins_name] ||= {:uptime => {}}
-          @brain[ins_name][:uptime][yyyymm] ||= 0
-          @brain[ins_name][:uptime][yyyymm] += uptime
+          @gem_brain[ins_name] ||= {:uptime => {}}
+          @gem_brain[ins_name][:uptime][yyyymm] ||= 0
+          @gem_brain[ins_name][:uptime][yyyymm] += uptime
         end
 
         # 料金計算で使用するためインスタンスタイプ情報を保持
         def save_ins_type(ins_name, ins_type, yyyymm = nil)
           puts "Ruboty::Ec2::Helpers::Brain.save_ins_type called"
           yyyymm = Time.now.strftime('%Y%m') if yyyymm.nil?
-          @brain[ins_name] ||= {}
-          @brain[ins_name][:ins_type] ||= {}
-          @brain[ins_name][:ins_type][yyyymm] = ins_type
+          @gem_brain[ins_name] ||= {}
+          @gem_brain[ins_name][:ins_type] ||= {}
+          @gem_brain[ins_name][:ins_type][yyyymm] = ins_type
         end
 
         # 料金計算で使用するためRHEL or CentOSの情報を保持
@@ -36,16 +38,15 @@ module Ruboty
           _os_type = (os_type == "centos" ? "centos" : "rhel")
           yyyymm = Time.now.strftime('%Y%m') if yyyymm.nil?
           puts "  ins_name[#{ins_name}]\n  os_type [#{_os_type}]\n  yyyymm  [#{yyyymm}]"
-          @brain[ins_name] ||= {}
-          @brain[ins_name][:os_type] ||= {}
-          @brain[ins_name][:os_type][yyyymm] = _os_type
+          @gem_brain[ins_name] ||= {}
+          @gem_brain[ins_name][:os_type] ||= {}
+          @gem_brain[ins_name][:os_type][yyyymm] = _os_type
         end
 
         def get_ins_infos(yyyymm)
           puts "Ruboty::Ec2::Helpers::Brain.get_ins_infos called"
           ins_infos = {}
-          #p @brain
-          @brain.each do |ins_name, ins_data|
+          @gem_brain.each do |ins_name, ins_data|
             next if ins_data[:uptime].nil?   or ins_data[:uptime][yyyymm].nil?
             next if ins_data[:ins_type].nil? or ins_data[:ins_type][yyyymm].nil?
             next if ins_data[:os_type].nil?  or ins_data[:os_type][yyyymm].nil?
@@ -55,6 +56,18 @@ module Ruboty
             ins_infos[ins_name][:ins_type] = ins_data[:ins_type][yyyymm]
           end
           ins_infos
+        end
+
+        def save_slack_user_list(user_infos)
+          today = Time.now.strftime('%Y-%m-%d')
+          @cmn_brain['slack'] ||= {}
+          @cmn_brain['slack'][:last_update] = today
+          @cmn_brain['slack'][:user_info]   = user_infos
+        end
+
+        def get_slack_user_list
+          @cmn_brain['slack'] ||= {}
+          @cmn_brain['slack']
         end
 
       end

--- a/lib/ruboty/ec2/helpers/slack.rb
+++ b/lib/ruboty/ec2/helpers/slack.rb
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+## Ruboty::Ec2::Helpers::Slack
+
+require 'addressable/uri'
+
+module Ruboty
+  module Ec2
+    module Helpers
+      class Slack
+        # set const var
+        SLACK_USERS_API = "https://slack.com/api/users.list"
+        SLACK_API_TOKEN = ENV['SLACK_API_TOKEN']
+
+        def initialize(message)
+          @message = message
+        end
+
+        # Slack APIを使用してUserList取得
+        def get_slack_user_list
+          uri   = Addressable::URI.parse(SLACK_USERS_API)
+          query = {token: SLACK_API_TOKEN, presence: 0}
+    
+          uri.query_values ||= {}
+          uri.query_values   = uri.query_values.merge(query)
+    
+          res_json = Net::HTTP.get(URI.parse(uri))
+          res_hash = JSON.parse(res_json, {:symbolize_names => true})
+          users_hash = {}
+          res_hash[:members].each do |mem_hash|
+            next if mem_hash[:profile][:email].nil? or mem_hash[:profile][:email].empty?
+            next if mem_hash[:name].nil? or mem_hash[:name].empty?
+            email = mem_hash[:profile][:email]
+            name  = mem_hash[:name]
+            flag  = mem_hash[:deleted]
+            users_hash[name] = {:disabled => flag}
+          end
+          raise "api response : #{res_hash}" if res_hash.nil? or !res_hash[:ok]
+          users_hash
+        end
+      end
+    end
+  end
+end

--- a/lib/ruboty/ec2/version.rb
+++ b/lib/ruboty/ec2/version.rb
@@ -1,5 +1,5 @@
 module Ruboty
   module Ec2
-    VERSION = "0.7.5"
+    VERSION = "0.7.4"
   end
 end

--- a/lib/ruboty/handlers/ec2.rb
+++ b/lib/ruboty/handlers/ec2.rb
@@ -2,6 +2,7 @@ require "ruboty/ec2/helpers/util"
 require "ruboty/ec2/helpers/brain"
 require "ruboty/ec2/helpers/ec2"
 require "ruboty/ec2/helpers/r53"
+require "ruboty/ec2/helpers/slack"
 require "ruboty/ec2/actions/create"
 require "ruboty/ec2/actions/stop"
 require "ruboty/ec2/actions/start"
@@ -23,6 +24,7 @@ require "ruboty/ec2/actions/thaw"
 require "ruboty/ec2/actions/replicate"
 require "ruboty/ec2/actions/repliarch"
 require "ruboty/ec2/actions/privilege"
+require "ruboty/ec2/actions/owner"
 
 module Ruboty
   module Handlers
@@ -67,6 +69,8 @@ module Ruboty
       on /ec2 *freeze +(?<ins_name>\S+)\z/,   name: 'freeze',    description: 'freeze archive'
       on /ec2 *thaw +(?<ins_name>\S+)\z/,     name: 'thaw',      description: 'thaw frozen archive'
       on /ec2 +privilege +list\z/,            name: 'privilege', description: 'show privilege list'
+      on(/ec2 +owner +(?<cmd>transfer|absence) *(?<ins_name>\S+)* *(?<to_user>\S+)* *\z/,
+                                              name: 'owner',     description: 'manage ownership of instance')
 
       def create(message)
         Ruboty::Ec2::Actions::Create.new(message).call
@@ -150,6 +154,10 @@ module Ruboty
 
       def privilege(message)
         Ruboty::Ec2::Actions::Privilege.new(message).call
+      end
+
+      def owner(message)
+        Ruboty::Ec2::Actions::Owner.new(message).call
       end
     end
   end

--- a/ruboty-ec2.gemspec
+++ b/ruboty-ec2.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "ruboty"
   spec.add_runtime_dependency "aws-sdk", "~> 2.0.0"
+  spec.add_runtime_dependency "addressable"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "ruboty-redis"


### PR DESCRIPTION
現状のさくっとでは、チャットコマンドでインスタンスのOwner変更はできません。
例えば、インスタンスのOwnerが退職した等でOwnerを変更する必要がある場合、
AWSマネジメントコンソールからOwnerを変更する必要があります。
これをチャットから可能にするコマンドを追加します。

popy ec2 owner transfer {INS} {TO_USER}
　で{INS}インスタンスのOwnerを{TO_USER}に変更
popy ec2 owner absence
　でSlackユーザ 無効orユーザ名変更などでOwnerが存在しないインスタンスの一覧を表示
という仕様で考えています。
